### PR TITLE
Add refresh command for updating repositories

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -199,10 +199,9 @@ func GetCurrentBranch(repoDir string) (string, error) {
 func FetchAll(repoDir string) error {
 	cmd := exec.Command("git", "fetch", "--all")
 	cmd.Dir = repoDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	message := "fetching from all remotes"
 	
-	if err := cmd.Run(); err != nil {
+	if err := ui.RunCommandWithProgress(cmd, message); err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
 	
@@ -212,10 +211,9 @@ func FetchAll(repoDir string) error {
 func Pull(repoDir string) error {
 	cmd := exec.Command("git", "pull")
 	cmd.Dir = repoDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	message := "pulling changes"
 	
-	if err := cmd.Run(); err != nil {
+	if err := ui.RunCommandWithProgress(cmd, message); err != nil {
 		return fmt.Errorf("failed to pull: %w", err)
 	}
 	


### PR DESCRIPTION
## Summary
• Added new `refresh` command to update all repositories in a ramp project
• Implemented git helper functions: GetCurrentBranch, FetchAll, Pull, HasRemoteTrackingBranch
• Supports updating both source repositories and git worktrees

## Test plan
- [ ] Test `ramp refresh` on a project with source repos only
- [ ] Test `ramp refresh` on a project with active worktrees
- [ ] Verify error handling for repos without remote tracking branches
- [ ] Test the new git helper functions work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)