### PR TITLE
Add --refresh and --no-refresh flags to up command

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -26,6 +26,8 @@ type UpState struct {
 
 var prefixFlag string
 var targetFlag string
+var refreshFlag bool
+var noRefreshFlag bool
 
 var upCmd = &cobra.Command{
 	Use:   "up <feature-name>",
@@ -58,6 +60,8 @@ func init() {
 	rootCmd.AddCommand(upCmd)
 	upCmd.Flags().StringVar(&prefixFlag, "prefix", "", "Override the branch prefix (defaults to config default_branch_prefix)")
 	upCmd.Flags().StringVar(&targetFlag, "target", "", "Create feature from existing feature name, local branch, or remote branch")
+	upCmd.Flags().BoolVar(&refreshFlag, "refresh", false, "Force refresh all repositories before creating feature (overrides auto_refresh config)")
+	upCmd.Flags().BoolVar(&noRefreshFlag, "no-refresh", false, "Skip refresh for all repositories (overrides auto_refresh config)")
 }
 
 func runUp(featureName, prefix, target string) error {
@@ -76,27 +80,53 @@ func runUp(featureName, prefix, target string) error {
 		return err
 	}
 
+	// Validate that --refresh and --no-refresh are not both specified
+	if refreshFlag && noRefreshFlag {
+		return fmt.Errorf("cannot specify both --refresh and --no-refresh flags")
+	}
+
 	// Auto-initialize if needed
 	if err := autoInitializeIfNeeded(projectDir, cfg); err != nil {
 		return fmt.Errorf("auto-initialization failed: %w", err)
 	}
 
-	// Auto-refresh repositories that have auto_refresh enabled (or not explicitly disabled)
+	// Auto-refresh repositories based on flags and config
 	repos := cfg.GetRepos()
-	hasAutoRefreshRepos := false
-	for _, repo := range repos {
-		if repo.ShouldAutoRefresh() {
-			hasAutoRefreshRepos = true
-			break
+
+	// Determine if we should refresh based on flags and config
+	shouldRefreshRepos := false
+	if noRefreshFlag {
+		// --no-refresh: skip all refresh operations
+		shouldRefreshRepos = false
+	} else if refreshFlag {
+		// --refresh: force refresh for all repos
+		shouldRefreshRepos = true
+	} else {
+		// No flags: check if any repo has auto_refresh enabled
+		for _, repo := range repos {
+			if repo.ShouldAutoRefresh() {
+				shouldRefreshRepos = true
+				break
+			}
 		}
 	}
 
-	if hasAutoRefreshRepos {
+	if shouldRefreshRepos {
 		progress := ui.NewProgress()
 		progress.Start("Auto-refreshing repositories before creating feature")
 
 		for name, repo := range repos {
-			if repo.ShouldAutoRefresh() {
+			// Determine if this specific repo should be refreshed
+			shouldRefreshThisRepo := false
+			if refreshFlag {
+				// --refresh: force refresh all repos
+				shouldRefreshThisRepo = true
+			} else {
+				// No --refresh flag: respect repo config
+				shouldRefreshThisRepo = repo.ShouldAutoRefresh()
+			}
+
+			if shouldRefreshThisRepo {
 				repoDir := repo.GetRepoPath(projectDir)
 				RefreshRepository(repoDir, name, progress)
 			} else {


### PR DESCRIPTION
## Summary
- Implements #18 - adds `--refresh` and `--no-refresh` flags to the `ramp up` command
- Allows users to override per-repo `auto_refresh` config at command invocation
- `--refresh` forces refresh for all repos (even if `auto_refresh: false`)
- `--no-refresh` skips refresh for all repos (even if `auto_refresh: true`)
- Flags are mutually exclusive and will error if both are specified
- Maintains backward compatibility - existing behavior preserved when neither flag is provided

## Implementation Details
- Added flag validation to prevent conflicting options
- Updated auto-refresh logic with clear priority: CLI flags → config → default (true)
- Added helpful descriptions in `--help` output

## Test Plan
- [x] Build successful
- [x] `--help` shows both flags correctly
- [x] Mutual exclusivity validation works
- [x] All existing tests pass
- [x] Follows kgonyon's suggestion from issue comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)