### PR TITLE
Add version command to display ramp version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ builds:
       - arm64
     binary: ramp
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X ramp/cmd.version={{.Version}}
 
 archives:
   - format: tar.gz

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,9 +4,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	
+
 	"ramp/internal/ui"
 )
+
+var version = "dev"
 
 var rootCmd = &cobra.Command{
 	Use:   "ramp",

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display the version of ramp",
+	Long:  `Display the current version of the ramp CLI tool.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("ramp version %s\n", version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
## Summary
- Adds new `ramp version` command to display the installed version of ramp
- Version is injected at build time by GoReleaser using ldflags
- Local builds show "dev", released binaries show actual version (e.g., "1.2.3")
- Fixed non-functional ldflags configuration in `.goreleaser.yaml` by adding the missing version variable and updating the injection path

## Changes
- Added `version` variable to `cmd/root.go` (defaults to "dev")
- Created `cmd/version.go` with new version command
- Updated `.goreleaser.yaml` ldflags to inject into `ramp/cmd.version`

## Test plan
- [x] Build locally and verify `ramp version` shows "dev"
- [x] Verify command appears in help output
- [ ] After merge and release tag, verify released binary shows actual version

🤖 Generated with [Claude Code](https://claude.com/claude-code)