### PR TITLE
Fix linter error: remove redundant newline

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -535,7 +535,8 @@ func displayActiveFeatures(projectDir string, cfg *config.Config) error {
 
 	// Display in-flight features
 	if len(inFlightFeatures) > 0 {
-		fmt.Println("━━━ IN FLIGHT ━━━\n")
+		fmt.Println("━━━ IN FLIGHT ━━━")
+		fmt.Println()
 		for _, feature := range inFlightFeatures {
 			fmt.Printf("%s\n", feature.name)
 			for _, status := range feature.statuses {


### PR DESCRIPTION
Fixes CI build failure from PR #34.

The linter caught a redundant newline in `fmt.Println()` which already adds a newline automatically.

Changes:
- `fmt.Println("━━━ IN FLIGHT ━━━\n")` → `fmt.Println("━━━ IN FLIGHT ━━━")`
- Added explicit `fmt.Println()` for the blank line

Tested locally - all tests pass.