### PR TITLE
Add automatic fetch and progress indicators to status command

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -259,11 +259,22 @@ func FetchAll(repoDir string) error {
 	cmd := exec.Command("git", "fetch", "--all")
 	cmd.Dir = repoDir
 	message := "fetching from all remotes"
-	
+
 	if err := ui.RunCommandWithProgress(cmd, message); err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
-	
+
+	return nil
+}
+
+func FetchAllQuiet(repoDir string) error {
+	cmd := exec.Command("git", "fetch", "--all", "--quiet")
+	cmd.Dir = repoDir
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to fetch: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Automatically fetches remote information before displaying status (no more stale ahead/behind counts)
- Added `FetchAllQuiet()` function for silent background fetching
- Added progress spinners during:
  1. Remote fetch operations (runs in parallel across all repos)
  2. Feature worktree analysis (can be slow with many features/repos)

## Changes

### New Function: `FetchAllQuiet()`
- Runs `git fetch --all --quiet` without UI output
- Used for background fetching during status command

### Status Command Improvements
- Fetches all repos in parallel before collecting status
- Shows "Fetching remote information..." spinner during fetch
- Shows "Analyzing features..." spinner during feature worktree analysis
- Both spinners respect `--verbose` flag

## Benefits

- Users no longer need to run `ramp refresh` just to see accurate remote tracking status
- Clear visual feedback during potentially slow operations
- Faster overall experience due to parallel fetching

## Test plan

- [x] Built and tested `ramp status` with single repo
- [x] Verified spinner animations appear during fetch and analysis
- [x] Confirmed remote tracking info is now accurate without manual refresh
- [x] Verified `--verbose` flag still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)