### PR TITLE
Fix port allocation cleanup bug with trailing slashes in feature names

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -26,7 +26,7 @@ var downCmd = &cobra.Command{
 4. Prompting for confirmation if there are uncommitted changes`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		featureName := args[0]
+		featureName := strings.TrimRight(args[0], "/")
 		if err := runDown(featureName); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,9 +33,9 @@ Example:
 		commandName := args[0]
 		var featureName string
 		if len(args) > 1 {
-			featureName = args[1]
+			featureName = strings.TrimRight(args[1], "/")
 		}
-		
+
 		if err := runCustomCommand(commandName, featureName); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -48,7 +49,7 @@ rolled back to ensure no partial feature state remains.
 After creating worktrees, runs any setup script specified in the configuration.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		featureName := args[0]
+		featureName := strings.TrimRight(args[0], "/")
 		if err := runUp(featureName, prefixFlag, targetFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Key Changes
- Strip trailing slashes from feature names in `ramp down` to ensure port cleanup succeeds
- Add feature name normalization to `ramp up` to prevent mismatched port allocation keys
- Normalize feature names in `ramp run` for consistency across all commands

## Files Changed
- `cmd/down.go` - Normalize feature name argument before port release operation
- `cmd/up.go` - Add trailing slash trimming to ensure consistent port allocation keys
- `cmd/run.go` - Normalize feature name to maintain consistent port lookup

## Risks & Considerations
- No significant risks identified - changes are purely defensive normalization
- Backwards compatible - removing trailing slashes doesn't affect valid feature names
- Fixes orphaned port allocations that prevented users from reusing port numbers