### PR TITLE
Add --from option for up command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,27 @@
+---
+allowed-tools: Bash(git describe:*), Bash(git tag:*), Bash(git push:*)
+argument-hint: [major|minor|patch]
+description: Create and push a new semver git tag
+model: claude-haiku-4-5-20251001
+---
+
+## Current State
+
+- Latest git tag: !`git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0"`
+
+## Your Task
+
+Create a new git tag based on semantic versioning and push it to the remote.
+
+**Increment type**: $1 (defaults to "patch" if not provided)
+
+**Steps**:
+1. Parse the latest tag to extract the version numbers (format: vX.Y.Z)
+2. Increment the appropriate version component:
+   - `major`: increment X, reset Y and Z to 0 (e.g., v1.2.3 � v2.0.0)
+   - `minor`: increment Y, reset Z to 0 (e.g., v1.2.3 � v1.3.0)
+   - `patch`: increment Z (e.g., v1.2.3 � v1.2.4)
+3. Create the new tag: `git tag vX.Y.Z`
+4. Push the tag to origin: `git push origin vX.Y.Z`
+
+Confirm the new version before creating and pushing the tag.

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Binary build output
 ramp
 
-.claude
-
 # Demo project generated files
 demo/**/source/
 demo/**/trees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Ramp is a sophisticated CLI tool for managing multi-repository development workf
 - Provides detailed progress feedback with success/error states
 - Used automatically by other commands via `AutoInstallIfNeeded()` function
 
-#### `ramp up <feature-name>`
+#### `ramp up [feature-name]`
 **Purpose**: Create a new feature branch with git worktrees for all configured repositories.
 **How it works**:
 - Auto-installs the project if repositories aren't cloned yet (calls `ramp install` internally)
@@ -70,7 +70,13 @@ Ramp is a sophisticated CLI tool for managing multi-repository development workf
   - `RAMP_PORT`: allocated port number for this feature
   - `RAMP_REPO_PATH_<REPO>`: path variables for each repository
 - Supports `--prefix` flag to override branch naming prefix
+- Supports `--no-prefix` flag to disable branch prefix entirely (mutually exclusive with --prefix)
 - Supports `--target` flag to create feature from existing feature name, local branch, or remote branch
+- Supports `--from` flag to create from remote branch with automatic naming (mutually exclusive with --target, --prefix, --no-prefix):
+  - `ramp up --from claude/feature-123` creates `trees/feature-123/` with branch `claude/feature-123` tracking `origin/claude/feature-123`
+  - `ramp up my-name --from claude/feature-123` creates `trees/my-name/` with branch `claude/feature-123` tracking `origin/claude/feature-123`
+  - Automatically derives prefix from path before last "/" and feature name from last segment
+  - Always prepends `origin/` to remote branch reference
 - Supports `--refresh` flag to force refresh all repositories before creating feature (overrides auto_refresh config)
 - Supports `--no-refresh` flag to skip refresh for all repositories (overrides auto_refresh config)
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -28,11 +28,12 @@ type UpState struct {
 var prefixFlag string
 var noPrefixFlag bool
 var targetFlag string
+var fromFlag string
 var refreshFlag bool
 var noRefreshFlag bool
 
 var upCmd = &cobra.Command{
-	Use:   "up <feature-name>",
+	Use:   "up [feature-name]",
 	Short: "Create a new feature branch with git worktrees for all repositories",
 	Long: `Create a new feature branch by creating git worktrees for all repositories
 from their configured locations. This creates isolated working directories for each repo
@@ -44,14 +45,59 @@ flag to create the feature from a different source:
   - Local branch name: ramp up new-feature --target feature/my-branch
   - Remote branch name: ramp up new-feature --target origin/feature/my-branch
 
+Use the --from flag to create from a remote branch with automatic naming:
+  - Remote branch: ramp up --from claude/feature-123
+    Creates trees/feature-123/ with branch claude/feature-123 from origin/claude/feature-123
+  - Override name: ramp up my-name --from claude/feature-123
+    Creates trees/my-name/ with branch claude/feature-123 from origin/claude/feature-123
+
 The operation is atomic - if any step fails, all successful operations will be
 rolled back to ensure no partial feature state remains.
 
 After creating worktrees, runs any setup script specified in the configuration.`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		featureName := strings.TrimRight(args[0], "/")
-		if err := runUp(featureName, prefixFlag, targetFlag); err != nil {
+		var featureName string
+		var derivedPrefix string
+		var derivedTarget string
+
+		// Handle --from flag
+		if fromFlag != "" {
+			// Parse the from flag to extract prefix and feature name
+			lastSlash := strings.LastIndex(fromFlag, "/")
+			if lastSlash == -1 {
+				// No slash found - entire string is feature name, no prefix
+				derivedPrefix = ""
+				if len(args) == 0 {
+					featureName = fromFlag
+				} else {
+					featureName = strings.TrimRight(args[0], "/")
+				}
+			} else {
+				// Found slash - split into prefix and feature name
+				derivedPrefix = fromFlag[:lastSlash+1] // Include trailing slash
+				derivedName := fromFlag[lastSlash+1:]
+				if len(args) == 0 {
+					featureName = derivedName
+				} else {
+					featureName = strings.TrimRight(args[0], "/")
+				}
+			}
+
+			// Always prepend origin/ to the from value for the target
+			derivedTarget = "origin/" + fromFlag
+		} else {
+			// Traditional usage - feature name is required
+			if len(args) == 0 {
+				fmt.Fprintf(os.Stderr, "Error: feature-name is required when not using --from flag\n")
+				os.Exit(1)
+			}
+			featureName = strings.TrimRight(args[0], "/")
+			derivedPrefix = prefixFlag
+			derivedTarget = targetFlag
+		}
+
+		if err := runUp(featureName, derivedPrefix, derivedTarget); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -63,6 +109,7 @@ func init() {
 	upCmd.Flags().StringVar(&prefixFlag, "prefix", "", "Override the branch prefix (defaults to config default_branch_prefix)")
 	upCmd.Flags().BoolVar(&noPrefixFlag, "no-prefix", false, "Disable branch prefix for this feature (mutually exclusive with --prefix)")
 	upCmd.Flags().StringVar(&targetFlag, "target", "", "Create feature from existing feature name, local branch, or remote branch")
+	upCmd.Flags().StringVar(&fromFlag, "from", "", "Create from remote branch with automatic prefix/name derivation (mutually exclusive with --target, --prefix, --no-prefix)")
 	upCmd.Flags().BoolVar(&refreshFlag, "refresh", false, "Force refresh all repositories before creating feature (overrides auto_refresh config)")
 	upCmd.Flags().BoolVar(&noRefreshFlag, "no-refresh", false, "Skip refresh for all repositories (overrides auto_refresh config)")
 }
@@ -91,6 +138,19 @@ func runUp(featureName, prefix, target string) error {
 	// Validate that --prefix and --no-prefix are not both specified
 	if prefixFlag != "" && noPrefixFlag {
 		return fmt.Errorf("cannot specify both --prefix and --no-prefix flags")
+	}
+
+	// Validate that --from is mutually exclusive with --target, --prefix, and --no-prefix
+	if fromFlag != "" {
+		if targetFlag != "" {
+			return fmt.Errorf("cannot specify both --from and --target flags")
+		}
+		if prefixFlag != "" {
+			return fmt.Errorf("cannot specify both --from and --prefix flags")
+		}
+		if noPrefixFlag {
+			return fmt.Errorf("cannot specify both --from and --no-prefix flags")
+		}
 	}
 
 	// Auto-install if needed


### PR DESCRIPTION
## Key Changes
- Add `--from` flag to `ramp up` command for creating features from remote branches
- Automatically derives tree directory name from remote branch path (last segment after `/`)
- Supports both explicit feature names and auto-detection from branch reference
- Always prepends `origin/` to remote branch references for consistency

## Files Changed
- `cmd/up.go` - Implement `--from` flag with remote branch resolution logic and mutually exclusive flag validation
- `CLAUDE.md` - Document new `--from` flag behavior and usage examples
- `.claude/commands/release.md` - Add release command configuration
- `.gitignore` - Clean up unnecessary entries

## Risks & Considerations
- `--from` flag is mutually exclusive with `--target`, `--prefix`, and `--no-prefix` flags
- Automatically prepends `origin/` which assumes standard remote naming convention
- Remote branch must exist or command will fail with clear error message