### PR TITLE
fix: resolve symlink path comparison in feature detection on macOS

### DIFF
--- a/internal/config/tree_context.go
+++ b/internal/config/tree_context.go
@@ -26,14 +26,27 @@ func DetectFeatureFromWorkingDir(projectDir string) (string, error) {
 		return "", err
 	}
 
-	// Convert both to absolute paths for comparison
+	// Convert both to absolute paths and resolve symlinks for comparison
 	absProjectDir, err := filepath.Abs(projectDir)
 	if err != nil {
 		// If we can't resolve the project dir, we're probably not in it
 		return "", nil
 	}
 
+	// Resolve symlinks to handle macOS /var/folders -> /private/var/folders
+	absProjectDir, err = filepath.EvalSymlinks(absProjectDir)
+	if err != nil {
+		// If we can't evaluate symlinks, we're probably not in it
+		return "", nil
+	}
+
 	absWd, err := filepath.Abs(wd)
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve symlinks for working directory too
+	absWd, err = filepath.EvalSymlinks(absWd)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

Fixes test failures on macOS caused by symlink resolution differences in `DetectFeatureFromWorkingDir`.

## Problem

On macOS, `t.TempDir()` returns paths like `/var/folders/...` which are symlinked to `/private/var/folders/...`. When `os.Getwd()` is called after `os.Chdir()`, it returns the resolved path, but `filepath.Abs()` doesn't resolve symlinks. This caused the path comparison using `strings.HasPrefix()` to fail, returning empty feature names in all tests.

## Solution

Added `filepath.EvalSymlinks()` to canonicalize both the project directory and working directory paths before comparison. This ensures consistent path matching across platforms.

## Test Results

All tests now pass on macOS (darwin):
- `TestDetectFeatureFromWorkingDir`: 8/8 subtests passing
- `TestDetectFeatureFromWorkingDir_EdgeCases`: 3/3 subtests passing
- Coverage improved from 86.0% to 90.4% for `internal/config` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)