### PR TITLE
fix: Fix critical auto-update bugs in background checker

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,10 @@ commands to manage repositories and create feature branches.`,
 
 func Execute() {
 	// Spawn background update checker (fire and forget)
-	if autoupdate.IsAutoUpdateEnabled() {
+	// Skip if running the internal update check command to avoid recursive spawning
+	if len(os.Args) > 1 && os.Args[1] == "__internal_update_check" {
+		// Don't spawn when we ARE the background checker
+	} else if autoupdate.IsAutoUpdateEnabled() {
 		autoupdate.SpawnBackgroundChecker()
 	}
 

--- a/internal/autoupdate/background.go
+++ b/internal/autoupdate/background.go
@@ -1,6 +1,7 @@
 package autoupdate
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -34,7 +35,13 @@ func SpawnBackgroundChecker() {
 	cmd.Stderr = logFile
 
 	// Start and immediately forget (don't wait)
-	cmd.Start()
+	if err := cmd.Start(); err != nil {
+		// Log the error before closing
+		logFile.WriteString(fmt.Sprintf("Failed to spawn background checker: %v\n", err))
+		logFile.Close()
+		return
+	}
+
 	// Close the file in parent process - child has already inherited the file descriptor
 	logFile.Close()
 	// Note: Intentionally not calling cmd.Wait() - this is fire-and-forget

--- a/internal/autoupdate/brew.go
+++ b/internal/autoupdate/brew.go
@@ -81,12 +81,12 @@ func GetBrewInfo() (version string, tap string, err error) {
 	return parseBrewInfo(output)
 }
 
-// RunBrewUpdate updates the specified Homebrew tap.
-func RunBrewUpdate(tap string) error {
+// RunBrewUpdate updates all Homebrew taps to get the latest formulas.
+func RunBrewUpdate() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "brew", "update", tap)
+	cmd := exec.CommandContext(ctx, "brew", "update")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("brew update failed: %w\n%s", err, output)

--- a/internal/autoupdate/check.go
+++ b/internal/autoupdate/check.go
@@ -64,10 +64,10 @@ func RunBackgroundCheck(currentVersion string) {
 
 	logf("Latest version from brew: %s (tap: %s)", latestVersion, tap)
 
-	// STEP 5: Update Homebrew tap to get latest formula
-	logf("Updating Homebrew tap: %s", tap)
-	if err := RunBrewUpdate(tap); err != nil {
-		logf("Failed to update brew tap: %v", err)
+	// STEP 5: Update Homebrew to get latest formula
+	logf("Updating Homebrew taps...")
+	if err := RunBrewUpdate(); err != nil {
+		logf("Failed to update Homebrew: %v", err)
 		updateCache(cachePath, currentVersion, latestVersion, time.Now())
 		return
 	}


### PR DESCRIPTION
## Key Changes
- Fix `brew update` command - remove invalid tap parameter that was causing failures
- Prevent recursive spawning/fork bomb by skipping background spawn when running internal update check
- Add error handling and logging to background spawner for better debugging

## Files Changed
- `cmd/root.go` - Skip spawning background checker when running internal update command
- `internal/autoupdate/background.go` - Add error handling with logging to spawner
- `internal/autoupdate/brew.go` - Remove tap parameter from brew update command
- `internal/autoupdate/check.go` - Update logging messages

## Risks & Considerations
- Fixes critical fork bomb bug in v1.3.1 that could consume system resources
- No breaking changes - improves reliability of auto-update system
- Background update checks will now work correctly on Homebrew installs