### PR TITLE
fix: Ensure ~/.ramp directory exists before spawning background checker

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,6 +38,13 @@ func Execute() {
 		// Don't spawn when we ARE the background checker
 	} else if autoupdate.IsAutoUpdateEnabled() {
 		autoupdate.SpawnBackgroundChecker()
+	} else {
+		// DEBUG: Log why auto-update is disabled
+		if os.Getenv("RAMP_DEBUG_AUTOUPDATE") == "1" {
+			exePath, _ := os.Executable()
+			fmt.Fprintf(os.Stderr, "DEBUG: Auto-update disabled. Executable: %s, IsHomebrew: %v\n",
+				exePath, autoupdate.IsHomebrewInstall())
+		}
 	}
 
 	err := rootCmd.Execute()

--- a/internal/autoupdate/background.go
+++ b/internal/autoupdate/background.go
@@ -26,6 +26,11 @@ func SpawnBackgroundChecker() {
 
 	// Redirect output to log file
 	logPath := getLogPath()
+
+	// Ensure parent directory exists
+	dir, _ := getRampDir()
+	os.MkdirAll(dir, 0755)
+
 	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return // Can't open log file, skip


### PR DESCRIPTION
## Key Changes
- Create ~/.ramp directory before spawning background update checker to prevent silent failures
- Add RAMP_DEBUG_AUTOUPDATE environment variable for debugging auto-update behavior
- Fix silent failure when log file couldn't be created in non-existent directory

## Files Changed
- `cmd/root.go` - Add debug logging for auto-update status
- `internal/autoupdate/background.go` - Ensure directory exists before opening log file

## Risks & Considerations
- Fixes critical bug in v1.3.2 where background checker was spawning but immediately failing silently
- Auto-update will now work correctly on Homebrew installs after this release