### PR TITLE
fix: Resolve symlinks when detecting Homebrew install

### DIFF
--- a/internal/autoupdate/brew.go
+++ b/internal/autoupdate/brew.go
@@ -33,7 +33,15 @@ func IsHomebrewInstall() bool {
 	if err != nil {
 		return false
 	}
-	return isHomebrewPath(exePath)
+
+	// Resolve symlink to get actual path (e.g., /opt/homebrew/bin/ramp -> ../Cellar/ramp/1.3.3/bin/ramp)
+	resolvedPath, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		// If we can't resolve, fall back to original path
+		resolvedPath = exePath
+	}
+
+	return isHomebrewPath(resolvedPath)
 }
 
 // IsAutoUpdateEnabled checks if auto-update should be enabled.


### PR DESCRIPTION
## Key Changes
- Resolve symlink paths before checking Homebrew installation status
- Use filepath.EvalSymlinks() to convert /opt/homebrew/bin/ramp to /opt/homebrew/Cellar/ramp/X.X.X/bin/ramp
- Fixes root cause of auto-update not working on Homebrew installs

## Files Changed
- `internal/autoupdate/brew.go` - Update IsHomebrewInstall() to resolve symlinks

## Risks & Considerations
- Fixes critical bug in v1.3.3 where auto-update was completely disabled on Homebrew
- No breaking changes - improves functionality
- This was the final missing piece needed for full auto-update functionality