### PR TITLE
Fix setup script PATH in production builds

### DIFF
--- a/internal/operations/scripts.go
+++ b/internal/operations/scripts.go
@@ -26,7 +26,9 @@ func RunSetupScript(projectDir, treesDir, featureName string, cfg *config.Config
 
 	progress.Update(fmt.Sprintf("Running setup script: %s", cfg.Setup))
 
-	cmd := exec.Command("/bin/bash", scriptPath)
+	// Use login shell (-l) to source user's profile and get full PATH
+	// This ensures tools like bun, node, etc. are available in GUI environments
+	cmd := exec.Command("/bin/bash", "-l", scriptPath)
 	cmd.Dir = treesDir
 
 	// Set up environment variables
@@ -49,7 +51,9 @@ func RunCleanupScript(projectDir, treesDir, featureName string, cfg *config.Conf
 
 	progress.Update(fmt.Sprintf("Running cleanup script: %s", cfg.Cleanup))
 
-	cmd := exec.Command("/bin/bash", scriptPath)
+	// Use login shell (-l) to source user's profile and get full PATH
+	// This ensures tools like bun, node, etc. are available in GUI environments
+	cmd := exec.Command("/bin/bash", "-l", scriptPath)
 	cmd.Dir = treesDir
 
 	// Get allocated ports for this feature

--- a/ramp-ui/frontend/src/main/index.ts
+++ b/ramp-ui/frontend/src/main/index.ts
@@ -1,38 +1,8 @@
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
-import { spawn, execSync, ChildProcess } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import { autoUpdater } from 'electron-updater';
 import path from 'path';
 import http from 'http';
-
-function getShellEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-
-  try {
-    // Get PATH from user's login shell to inherit their full environment
-    // This ensures tools like bun, node, etc. are available to scripts
-    const shell = process.env.SHELL || '/bin/zsh';
-    const shellPath = execSync(`${shell} -l -c "echo $PATH"`, {
-      encoding: 'utf8',
-      timeout: 5000,
-    }).trim();
-
-    if (shellPath) {
-      env.PATH = shellPath;
-    }
-  } catch (err) {
-    console.warn('Failed to get PATH from login shell:', err);
-    // Fall back to adding common paths
-    const additionalPaths = [
-      '/opt/homebrew/bin',
-      '/usr/local/bin',
-      `${process.env.HOME}/.bun/bin`,
-    ].filter(Boolean);
-    const currentPath = env.PATH || '/usr/bin:/bin:/usr/sbin:/sbin';
-    env.PATH = [...additionalPaths, currentPath].join(':');
-  }
-
-  return env;
-}
 
 let mainWindow: BrowserWindow | null = null;
 let backendProcess: ChildProcess | null = null;
@@ -91,7 +61,6 @@ async function startBackend(): Promise<void> {
 
   backendProcess = spawn(backendPath, ['--port', String(BACKEND_PORT)], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: getShellEnv(),
   });
 
   backendProcess.stdout?.on('data', (data: Buffer) => {


### PR DESCRIPTION
## Key Changes
- Run setup/cleanup scripts with login shell (-l flag) to source user's shell profile
- Remove redundant getShellEnv() function from Electron main process
- Fixes bun/node tools not found in desktop app when running from GUI

## Files Changed
- `internal/operations/scripts.go` - Run bash with `-l` flag for setup/cleanup scripts
- `ramp-ui/frontend/src/main/index.ts` - Remove unnecessary PATH environment override

## Risks & Considerations
- Login shell adds slight startup overhead to scripts (negligible)
- No breaking changes - this is a pure fix for the production build PATH issue