### PR TITLE
Fix release tag configuration for desktop app

### DIFF
--- a/ramp-ui/frontend/electron-builder.yml
+++ b/ramp-ui/frontend/electron-builder.yml
@@ -48,3 +48,4 @@ publish:
   owner: FreedomForeverSolar
   repo: ramp
   releaseType: release
+  releaseTag: ui-v${version}


### PR DESCRIPTION
## Key Changes
- Add custom release tag format for desktop app releases (`ui-v${version}`)

## Files Changed
- `ramp-ui/frontend/electron-builder.yml` - Configure release tag prefix for Electron releases

## Risks & Considerations
- No significant risks identified