### PR TITLE
Update macOS desktop app download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ramp up my-feature # Start coding!
 
 Prefer a GUI? The Ramp desktop app provides a visual interface for managing your multi-repo projects with real-time progress updates, one-click feature creation, and custom command execution.
 
-**[Download for macOS](https://github.com/FreedomForeverSolar/ramp/releases)**
+**[Download for macOS](https://github.com/FreedomForeverSolar/ramp-desktop/releases)**
 
 <br clear="left">
 


### PR DESCRIPTION
## Key Changes
- Fix macOS desktop app download link to point to correct repository (ramp-desktop instead of ramp)

## Files Changed
- `README.md` - Update GitHub releases URL in desktop app section

## Risks & Considerations
- No significant risks identified