### PR TITLE
fix: stop spinner before streaming custom command output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -827,6 +827,10 @@ repos:
   - git: git@github.com:org/shared-lib.git    # RAMP_REPO_PATH_SHARED_LIB
 ```
 
+The path depends on context:
+- **Feature mode**: Points to the worktree path (`trees/<feature>/<repo>`)
+- **Source mode**: Points to the source path (`repos/<repo>`)
+
 Repository names are converted to valid environment variable names:
 1. Extract name from git URL (last path segment before `.git`)
 2. Convert to uppercase

--- a/docs/guides/custom-scripts.md
+++ b/docs/guides/custom-scripts.md
@@ -23,17 +23,25 @@ RAMP_TREES_DIR        # Path to feature's trees directory
 RAMP_WORKTREE_NAME    # Feature name
 RAMP_COMMAND_NAME     # Custom command name (for run hooks only)
 RAMP_PORT             # Allocated port number (if configured)
-RAMP_REPO_PATH_<NAME> # Path to each repository's source
+RAMP_REPO_PATH_<NAME> # Path to each repository (context-dependent)
 ```
 
 ### Example Values
 
+**Feature mode** (running against a feature worktree):
 ```bash
 RAMP_PROJECT_DIR=/home/user/my-project
 RAMP_TREES_DIR=/home/user/my-project/trees/my-feature
 RAMP_WORKTREE_NAME=my-feature
 RAMP_COMMAND_NAME=deploy        # Only set for run hooks
 RAMP_PORT=3000
+RAMP_REPO_PATH_FRONTEND=/home/user/my-project/trees/my-feature/frontend
+RAMP_REPO_PATH_API=/home/user/my-project/trees/my-feature/api
+```
+
+**Source mode** (running against source repos, no feature):
+```bash
+RAMP_PROJECT_DIR=/home/user/my-project
 RAMP_REPO_PATH_FRONTEND=/home/user/my-project/repos/frontend
 RAMP_REPO_PATH_API=/home/user/my-project/repos/api
 ```

--- a/internal/operations/operations_test.go
+++ b/internal/operations/operations_test.go
@@ -18,6 +18,7 @@ type MockProgressReporter struct {
 func (m *MockProgressReporter) Start(message string)                        { m.Messages = append(m.Messages, "start: "+message) }
 func (m *MockProgressReporter) Update(message string)                       { m.Messages = append(m.Messages, "update: "+message) }
 func (m *MockProgressReporter) UpdateWithProgress(message string, pct int)  { m.Messages = append(m.Messages, "progress: "+message) }
+func (m *MockProgressReporter) Stop()                                       { m.Messages = append(m.Messages, "stop") }
 func (m *MockProgressReporter) Success(message string)                      { m.Messages = append(m.Messages, "success: "+message) }
 func (m *MockProgressReporter) Error(message string)                        { m.Messages = append(m.Messages, "error: "+message) }
 func (m *MockProgressReporter) Warning(message string)                      { m.Messages = append(m.Messages, "warning: "+message) }

--- a/internal/operations/progress.go
+++ b/internal/operations/progress.go
@@ -13,6 +13,10 @@ type ProgressReporter interface {
 	// CLI implementations may ignore the percentage.
 	UpdateWithProgress(message string, percentage int)
 
+	// Stop halts progress indication without a status message.
+	// Use this before streaming command output to avoid visual conflicts.
+	Stop()
+
 	// Success ends the current phase successfully.
 	Success(message string)
 

--- a/internal/operations/progress_cli.go
+++ b/internal/operations/progress_cli.go
@@ -27,6 +27,10 @@ func (r *CLIProgressReporter) UpdateWithProgress(message string, _ int) {
 	r.progress.Update(message)
 }
 
+func (r *CLIProgressReporter) Stop() {
+	r.progress.Stop()
+}
+
 func (r *CLIProgressReporter) Success(message string) {
 	r.progress.Success(message)
 }

--- a/internal/operations/progress_ws.go
+++ b/internal/operations/progress_ws.go
@@ -54,6 +54,10 @@ func (r *WSProgressReporter) UpdateWithProgress(message string, percentage int) 
 	r.broadcast(WSMessage{Type: "progress", Operation: r.operation, Message: message, Percentage: percentage, Target: r.target, Command: r.command})
 }
 
+func (r *WSProgressReporter) Stop() {
+	// No-op for WebSocket - there's no spinner to stop
+}
+
 func (r *WSProgressReporter) Success(message string) {
 	r.broadcast(WSMessage{Type: "progress", Operation: r.operation, Message: message, Target: r.target, Command: r.command})
 }

--- a/internal/operations/run.go
+++ b/internal/operations/run.go
@@ -185,11 +185,11 @@ func runInFeature(opts RunOptions, scriptPath, treesDir string) (int, error) {
 		}
 	}
 
-	// Add repo path variables
+	// Add repo path variables (use worktree paths in feature mode)
 	repos := cfg.GetRepos()
-	for name, repo := range repos {
+	for name := range repos {
 		envVarName := config.GenerateEnvVarName(name)
-		repoPath := repo.GetRepoPath(projectDir)
+		repoPath := filepath.Join(treesDir, name)
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envVarName, repoPath))
 	}
 
@@ -200,6 +200,9 @@ func runInFeature(opts RunOptions, scriptPath, treesDir string) (int, error) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
+
+	// Stop spinner before streaming output to avoid visual conflicts
+	opts.Progress.Stop()
 
 	return executeWithStreaming(cmd, opts.Output, opts.Cancel, opts.ProcessCallback)
 }
@@ -234,6 +237,9 @@ func runInSource(opts RunOptions, scriptPath string) (int, error) {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
+
+	// Stop spinner before streaming output to avoid visual conflicts
+	opts.Progress.Stop()
 
 	return executeWithStreaming(cmd, opts.Output, opts.Cancel, opts.ProcessCallback)
 }

--- a/internal/operations/run_test.go
+++ b/internal/operations/run_test.go
@@ -1,0 +1,236 @@
+package operations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ramp/internal/config"
+)
+
+// MockOutputStreamer captures command output for testing
+type MockOutputStreamer struct {
+	Lines      []string
+	ErrorLines []string
+}
+
+func (m *MockOutputStreamer) WriteLine(line string) {
+	m.Lines = append(m.Lines, line)
+}
+
+func (m *MockOutputStreamer) WriteErrorLine(line string) {
+	m.ErrorLines = append(m.ErrorLines, line)
+}
+
+// AddCommand adds a custom command to the test project config
+func (tp *TestProject) AddCommand(name, scriptContent string) {
+	tp.t.Helper()
+
+	scriptsDir := filepath.Join(tp.RampDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		tp.t.Fatalf("failed to create scripts dir: %v", err)
+	}
+
+	scriptPath := filepath.Join(scriptsDir, name+".sh")
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0755); err != nil {
+		tp.t.Fatalf("failed to write script: %v", err)
+	}
+
+	tp.Config.Commands = append(tp.Config.Commands, &config.Command{
+		Name:    name,
+		Command: "scripts/" + name + ".sh",
+	})
+
+	if err := config.SaveConfig(tp.Config, tp.Dir); err != nil {
+		tp.t.Fatalf("failed to save config: %v", err)
+	}
+}
+
+// === RUN OPERATION TESTS ===
+
+func TestRunCommand_RepoPathEnvVars_FeatureMode(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("frontend")
+	tp.InitRepo("api")
+
+	// Create a command that prints RAMP_REPO_PATH_* env vars
+	tp.AddCommand("print-paths", `#!/bin/bash
+env | grep RAMP_REPO_PATH | sort
+`)
+
+	progress := &MockProgressReporter{}
+
+	// Create a feature first
+	_, err := Up(UpOptions{
+		FeatureName: "test-feature",
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		Progress:    progress,
+		SkipRefresh: true,
+	})
+	if err != nil {
+		t.Fatalf("Up() error = %v", err)
+	}
+
+	// Run command in feature mode
+	output := &MockOutputStreamer{}
+	_, err = RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "print-paths",
+		FeatureName: "test-feature",
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// In feature mode, RAMP_REPO_PATH_* should point to trees/<feature>/<repo>
+	expectedTreesDir := filepath.Join(tp.Dir, "trees", "test-feature")
+
+	foundFrontend := false
+	foundAPI := false
+
+	for _, line := range output.Lines {
+		if path, ok := strings.CutPrefix(line, "RAMP_REPO_PATH_FRONTEND="); ok {
+			expectedPath := filepath.Join(expectedTreesDir, "frontend")
+			if path != expectedPath {
+				t.Errorf("RAMP_REPO_PATH_FRONTEND = %q, want %q (worktree path)", path, expectedPath)
+			}
+			foundFrontend = true
+		}
+		if path, ok := strings.CutPrefix(line, "RAMP_REPO_PATH_API="); ok {
+			expectedPath := filepath.Join(expectedTreesDir, "api")
+			if path != expectedPath {
+				t.Errorf("RAMP_REPO_PATH_API = %q, want %q (worktree path)", path, expectedPath)
+			}
+			foundAPI = true
+		}
+	}
+
+	if !foundFrontend {
+		t.Error("RAMP_REPO_PATH_FRONTEND not found in output")
+	}
+	if !foundAPI {
+		t.Error("RAMP_REPO_PATH_API not found in output")
+	}
+}
+
+func TestRunCommand_RepoPathEnvVars_SourceMode(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("frontend")
+	tp.InitRepo("api")
+
+	// Create a command that prints RAMP_REPO_PATH_* env vars
+	tp.AddCommand("print-paths", `#!/bin/bash
+env | grep RAMP_REPO_PATH | sort
+`)
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	// Run command in source mode (no feature name)
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "print-paths",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// In source mode, RAMP_REPO_PATH_* should point to repos/<repo>
+	foundFrontend := false
+	foundAPI := false
+
+	for _, line := range output.Lines {
+		if path, ok := strings.CutPrefix(line, "RAMP_REPO_PATH_FRONTEND="); ok {
+			expectedPath := filepath.Join(tp.Dir, "repos", "frontend")
+			if path != expectedPath {
+				t.Errorf("RAMP_REPO_PATH_FRONTEND = %q, want %q (source path)", path, expectedPath)
+			}
+			foundFrontend = true
+		}
+		if path, ok := strings.CutPrefix(line, "RAMP_REPO_PATH_API="); ok {
+			expectedPath := filepath.Join(tp.Dir, "repos", "api")
+			if path != expectedPath {
+				t.Errorf("RAMP_REPO_PATH_API = %q, want %q (source path)", path, expectedPath)
+			}
+			foundAPI = true
+		}
+	}
+
+	if !foundFrontend {
+		t.Error("RAMP_REPO_PATH_FRONTEND not found in output")
+	}
+	if !foundAPI {
+		t.Error("RAMP_REPO_PATH_API not found in output")
+	}
+}
+
+func TestRunCommand_RepoPathEnvVars_FeatureMode_NotSourcePath(t *testing.T) {
+	// This test explicitly verifies the bug: in feature mode,
+	// RAMP_REPO_PATH_* should NOT point to source repos
+	tp := NewTestProject(t)
+	tp.InitRepo("myrepo")
+
+	tp.AddCommand("print-paths", `#!/bin/bash
+env | grep RAMP_REPO_PATH | sort
+`)
+
+	progress := &MockProgressReporter{}
+
+	// Create a feature
+	_, err := Up(UpOptions{
+		FeatureName: "my-feature",
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		Progress:    progress,
+		SkipRefresh: true,
+	})
+	if err != nil {
+		t.Fatalf("Up() error = %v", err)
+	}
+
+	output := &MockOutputStreamer{}
+	_, err = RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "print-paths",
+		FeatureName: "my-feature",
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// The bug: RAMP_REPO_PATH_* incorrectly points to repos/ instead of trees/
+	sourceReposPath := filepath.Join(tp.Dir, "repos")
+
+	for _, line := range output.Lines {
+		if strings.HasPrefix(line, "RAMP_REPO_PATH_") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			path := parts[1]
+
+			// In feature mode, paths should NOT contain /repos/
+			if strings.HasPrefix(path, sourceReposPath) {
+				t.Errorf("Bug detected: %s points to source repos path %q, should point to trees path", parts[0], path)
+			}
+
+			// Paths SHOULD contain /trees/<feature>/
+			expectedPrefix := filepath.Join(tp.Dir, "trees", "my-feature")
+			if !strings.HasPrefix(path, expectedPrefix) {
+				t.Errorf("%s = %q, should start with %q", parts[0], path, expectedPrefix)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Key Changes
- Add `Stop()` method to `ProgressReporter` interface to halt spinner without status message
- Call `Stop()` before streaming command output in `runInFeature()` and `runInSource()`
- Fix repo path environment variables to use worktree paths instead of source paths in feature context
- Add comprehensive tests for the `Run` operation covering various scenarios
- Update documentation for custom scripts and configuration

## Files Changed
- `internal/operations/progress.go` - Add `Stop()` to interface
- `internal/operations/progress_cli.go` - Implement `Stop()` for CLI
- `internal/operations/progress_ws.go` - Implement `Stop()` as no-op for WebSocket
- `internal/operations/run.go` - Call `Stop()` before streaming, fix env var paths
- `internal/operations/run_test.go` - New test file with comprehensive coverage
- `docs/` - Documentation updates

## Risks & Considerations
- Interface change adds new method - all implementations must be updated (done in this PR)
- No breaking changes to external behavior