### PR TITLE
feat: add RAMP_DISPLAY_NAME environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,7 @@ Scripts and hooks receive these variables:
 - `RAMP_PROJECT_DIR` - Project root
 - `RAMP_TREES_DIR` - Feature trees directory
 - `RAMP_WORKTREE_NAME` - Feature name
+- `RAMP_DISPLAY_NAME` - Human-readable display name (if set via `--name` flag)
 - `RAMP_COMMAND_NAME` - Command name (for `run` hooks only)
 - `RAMP_PORT` - Allocated port (if configured)
 - `RAMP_REPO_PATH_<REPO>` - Path to each repo (uppercase, underscores)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ brew install freedomforeversolar/tools/ramp
 git clone https://github.com/FreedomForeverSolar/ramp.git
 cd ramp
 go build -o ramp .
-sudo ./install.sh
+./install.sh
 ```
 
 ### Auto-Updates
@@ -156,6 +156,7 @@ commands:
 Scripts receive environment variables for automation:
 - `RAMP_PORT` - Unique port for this feature
 - `RAMP_TREES_DIR` - Feature workspace path
+- `RAMP_DISPLAY_NAME` - Human-readable name (if set via `--name`)
 - `RAMP_REPO_PATH_<NAME>` - Path to each repository
 
 See [docs/configuration.md](docs/configuration.md) for full reference.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -810,6 +810,7 @@ All scripts (setup, cleanup, custom commands, hooks) receive these environment v
 | `RAMP_PROJECT_DIR` | Absolute path to project root | `/home/user/my-project` |
 | `RAMP_TREES_DIR` | Path to feature's trees directory | `/home/user/my-project/trees/my-feature` |
 | `RAMP_WORKTREE_NAME` | Feature name | `my-feature` |
+| `RAMP_DISPLAY_NAME` | Human-readable display name (if set via `--name` flag) | `My Feature` |
 | `RAMP_COMMAND_NAME` | Custom command name (for `run` hooks only) | `deploy` |
 | `RAMP_PORT` | First allocated port (backward compatible) | `3000` |
 | `RAMP_PORT_1` | First allocated port | `3000` |

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 set -e
 
+# Prevent running entire script as root (causes go build cache issues)
+if [ "$EUID" -eq 0 ]; then
+    echo "Error: Don't run this script with sudo."
+    echo "The script will prompt for sudo when needed."
+    exit 1
+fi
+
 echo "Building ramp..."
 go build -o ramp .
 
 echo "Installing to /usr/local/bin..."
-cp ramp /usr/local/bin/
+if [ -w /usr/local/bin ]; then
+    cp ramp /usr/local/bin/
+else
+    sudo cp ramp /usr/local/bin/
+fi
 
-echo "✅ ramp installed successfully!"
+echo "ramp installed successfully!"
 echo "You can now run 'ramp --help' from anywhere"

--- a/internal/operations/up.go
+++ b/internal/operations/up.go
@@ -319,7 +319,7 @@ func Up(opts UpOptions) (*UpResult, error) {
 	if HasEnvFiles(repos) {
 		progress.UpdateWithProgress("Processing environment files...", 65)
 
-		envVars := BuildEnvVars(projectDir, treesDir, featureName, allocatedPorts, cfg, repos)
+		envVars := BuildEnvVars(projectDir, treesDir, featureName, opts.DisplayName, allocatedPorts, cfg, repos)
 
 		for name, repo := range repos {
 			if len(repo.EnvFiles) > 0 {
@@ -348,7 +348,7 @@ func Up(opts UpOptions) (*UpResult, error) {
 	if cfg.Setup != "" {
 		progress.UpdateWithProgress("Running setup script...", 80)
 
-		if err := RunSetupScript(projectDir, treesDir, featureName, cfg, allocatedPorts, repos, progress, opts.Output); err != nil {
+		if err := RunSetupScript(projectDir, treesDir, featureName, opts.DisplayName, cfg, allocatedPorts, repos, progress, opts.Output); err != nil {
 			progress.Error("Setup script failed")
 			for _, state := range states {
 				state.setupRan = true
@@ -378,7 +378,7 @@ func Up(opts UpOptions) (*UpResult, error) {
 	// Phase 8: Execute up hooks (after setup script)
 	mergedCfg, err := config.LoadMergedConfig(projectDir)
 	if err == nil && len(mergedCfg.Hooks) > 0 {
-		hookEnv := BuildEnvVars(projectDir, treesDir, featureName, allocatedPorts, cfg, repos)
+		hookEnv := BuildEnvVars(projectDir, treesDir, featureName, opts.DisplayName, allocatedPorts, cfg, repos)
 		hooks.ExecuteHooks(hooks.Up, mergedCfg.Hooks, projectDir, treesDir, hookEnv, progress)
 	}
 


### PR DESCRIPTION
## Key Changes
- Add `RAMP_DISPLAY_NAME` env var to setup scripts, cleanup scripts, hooks, and custom commands
- Create centralized `LoadDisplayName()` and `BuildScriptEnv()` helpers in `env.go`
- Remove duplicated env-building logic from `scripts.go` and `run.go`
- Fix `install.sh` to prevent `go build` running as root (corrupts build cache)

## Files Changed
- `internal/operations/env.go` - New helpers for display name loading and script env building
- `internal/operations/scripts.go` - Simplified to use new `BuildScriptEnv()` helper
- `internal/operations/run.go` - Uses `LoadDisplayName()` for feature mode, removed dead code
- `internal/operations/down.go` - Loads display name from metadata for hooks/cleanup
- `internal/operations/up.go` - Passes display name to env builders
- `install.sh` - Prevents running as root, only uses sudo for cp step
- `CLAUDE.md`, `README.md`, `docs/configuration.md` - Document new env var

## Risks & Considerations
- No breaking changes - `RAMP_DISPLAY_NAME` is empty string if not set
- Install script now errors if run with `sudo` (intentional behavior change)