### PR TITLE
fix(ramp-ui): remove git repo requirement for adding projects

### DIFF
--- a/internal/uiapi/projects.go
+++ b/internal/uiapi/projects.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 
 	"ramp/internal/config"
-	"ramp/internal/git"
 
 	"github.com/gorilla/mux"
 )
@@ -52,12 +51,6 @@ func (s *Server) AddProject(w http.ResponseWriter, r *http.Request) {
 	configPath := filepath.Join(req.Path, ".ramp", "ramp.yaml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		writeError(w, http.StatusBadRequest, "Not a valid Ramp project", "Missing .ramp/ramp.yaml")
-		return
-	}
-
-	// Validate this is a git repository
-	if !git.IsGitRepo(req.Path) {
-		writeError(w, http.StatusBadRequest, "Not a valid Ramp project", "Directory is not a git repository. If you downloaded a zip file, please clone the repository instead.")
 		return
 	}
 

--- a/internal/uiapi/projects_test.go
+++ b/internal/uiapi/projects_test.go
@@ -170,6 +170,57 @@ func TestAddProject_NotRampProject(t *testing.T) {
 	}
 }
 
+func TestAddProject_Success(t *testing.T) {
+	cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Create a valid ramp project (with .ramp/ramp.yaml, no .git)
+	tempDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tempDir, ".ramp"), 0755)
+	os.WriteFile(filepath.Join(tempDir, ".ramp", "ramp.yaml"), []byte("name: test-project\nrepos: []\n"), 0644)
+
+	server := NewServer()
+
+	body := AddProjectRequest{Path: tempDir}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.AddProject(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("AddProject() status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
+func TestAddProject_SuccessWithGit(t *testing.T) {
+	cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Create a valid ramp project that also has .git
+	tempDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tempDir, ".ramp"), 0755)
+	os.WriteFile(filepath.Join(tempDir, ".ramp", "ramp.yaml"), []byte("name: test-project\nrepos: []\n"), 0644)
+	os.MkdirAll(filepath.Join(tempDir, ".git"), 0755)
+
+	server := NewServer()
+
+	body := AddProjectRequest{Path: tempDir}
+	bodyBytes, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	server.AddProject(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("AddProject() status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
 func TestAddProject_InvalidJSON(t *testing.T) {
 	cleanup := setupTestConfig(t)
 	defer cleanup()


### PR DESCRIPTION
## Key Changes
- Remove the validation check requiring project root to be a git repository when adding projects in the desktop app
- Remove the now-unused `internal/git` import from `projects.go`
- Add tests for successfully adding projects both with and without `.git` at the root

## Files Changed
- `internal/uiapi/projects.go` — removed git repo validation and unused import
- `internal/uiapi/projects_test.go` — added `TestAddProject_Success` and `TestAddProject_SuccessWithGit`

## Risks & Considerations
- No significant risks identified — the project root was never used for any git operations; all git work targets individual repos inside `repos/` and worktrees inside `trees/`