### PR TITLE
feat(status): add --refresh flag to refresh repos before showing status

### DIFF
--- a/docs/commands/ramp_status.md
+++ b/docs/commands/ramp_status.md
@@ -16,9 +16,10 @@ ramp status [flags]
 ### Options
 
 ```
-  -h, --help   help for status
-      --json   Output status as JSON (useful for scripts)
-      --tree   Output only the current tree/feature name (if in one)
+  -h, --help      help for status
+      --json      Output status as JSON (useful for scripts)
+  -r, --refresh   Refresh repositories before showing status
+      --tree      Output only the current tree/feature name (if in one)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Key Changes
- Add `-r`/`--refresh` flag to `ramp status` command
- Refreshes all repositories before displaying status (combines `ramp refresh && ramp status`)
- Surfaces per-repo warnings during refresh operation
- Skips redundant fetch when refresh already ran (performance optimization)
- Marks `--refresh` as mutually exclusive with `--tree` and `--json` flags

## Files Changed
- `cmd/status.go` - Added flag registration, refresh logic, and mutual exclusivity constraints

## Risks & Considerations
- No breaking changes - new optional flag only
- Reuses existing `RefreshRepositoriesParallel` function for consistency with `ramp refresh`