### PR TITLE
feat(run): support arbitrary shell commands in command field

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -156,9 +156,9 @@ func TestRunCommandScriptNotFound(t *testing.T) {
 		t.Fatal("runCustomCommand() should fail for missing script file")
 	}
 
-	// Error should contain "command script not found"
-	if !strings.Contains(err.Error(), "command script not found") {
-		t.Errorf("error should contain 'command script not found', got %q", err.Error())
+	// Error should contain "script not found"
+	if !strings.Contains(err.Error(), "script not found") {
+		t.Errorf("error should contain 'script not found', got %q", err.Error())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,44 @@ type Hook struct {
 	BaseDir string `yaml:"-"`             // Set during merge, excluded from YAML
 }
 
+// ResolvedCommand holds the result of resolving a command string.
+type ResolvedCommand struct {
+	Path           string // Resolved script path or shell command string
+	IsShellCommand bool   // True if this is a shell command (contains spaces)
+}
+
+// ResolveCommand determines whether a command string is a shell command or file path,
+// and resolves file paths using baseDir with a projectDir fallback.
+//
+// Heuristic: commands containing a space are shell commands (e.g., "bun scripts/test.ts"),
+// commands without spaces are file paths (e.g., "scripts/test.sh").
+//
+// For file paths, resolution order is: absolute path > baseDir > projectDir/.ramp/ fallback.
+// Returns an error if a file path does not exist on disk.
+func ResolveCommand(command, baseDir, projectDir string) (ResolvedCommand, error) {
+	// Trim whitespace to handle YAML quirks (e.g., trailing spaces)
+	command = strings.TrimSpace(command)
+
+	if strings.Contains(command, " ") {
+		return ResolvedCommand{Path: command, IsShellCommand: true}, nil
+	}
+
+	var scriptPath string
+	if filepath.IsAbs(command) {
+		scriptPath = command
+	} else if baseDir != "" {
+		scriptPath = filepath.Join(baseDir, command)
+	} else {
+		scriptPath = filepath.Join(projectDir, ".ramp", command)
+	}
+
+	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+		return ResolvedCommand{}, fmt.Errorf("script not found: %s", scriptPath)
+	}
+
+	return ResolvedCommand{Path: scriptPath, IsShellCommand: false}, nil
+}
+
 type PromptOption struct {
 	Value string `yaml:"value"`
 	Label string `yaml:"label"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Command struct {
 // Hook represents a script to execute at a specific lifecycle event.
 type Hook struct {
 	Event   string `yaml:"event"`         // up, down, run
-	Command string `yaml:"command"`       // Path to script relative to .ramp/
+	Command string `yaml:"command"`       // Script path (relative to .ramp/) or shell command (if contains spaces)
 	For     string `yaml:"for,omitempty"` // For run hooks: command name, prefix pattern (e.g., "test-*"), or empty for all
 	BaseDir string `yaml:"-"`             // Set during merge, excluded from YAML
 }
@@ -81,6 +81,12 @@ type ResolvedCommand struct {
 func ResolveCommand(command, baseDir, projectDir string) (ResolvedCommand, error) {
 	// Trim whitespace to handle YAML quirks (e.g., trailing spaces)
 	command = strings.TrimSpace(command)
+
+	// Reject empty commands early - an empty string would resolve to a directory
+	// path that passes os.Stat but fails at execution
+	if command == "" {
+		return ResolvedCommand{}, fmt.Errorf("command is empty")
+	}
 
 	if strings.Contains(command, " ") {
 		return ResolvedCommand{Path: command, IsShellCommand: true}, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1584,3 +1584,211 @@ repos:
 		t.Error("LoadConfig() should return error for duplicate repo names")
 	}
 }
+
+// TestResolveCommand tests the ResolveCommand function for shell commands vs file paths
+func TestResolveCommand(t *testing.T) {
+	// Create temp directory with test scripts
+	tempDir := t.TempDir()
+	rampDir := filepath.Join(tempDir, ".ramp")
+	scriptsDir := filepath.Join(rampDir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+
+	// Create a test script
+	testScript := filepath.Join(scriptsDir, "test.sh")
+	if err := os.WriteFile(testScript, []byte("#!/bin/bash\necho test"), 0755); err != nil {
+		t.Fatalf("failed to write test script: %v", err)
+	}
+
+	// Create a script in a custom baseDir
+	customDir := filepath.Join(tempDir, "custom")
+	if err := os.MkdirAll(customDir, 0755); err != nil {
+		t.Fatalf("failed to create custom dir: %v", err)
+	}
+	customScript := filepath.Join(customDir, "custom.sh")
+	if err := os.WriteFile(customScript, []byte("#!/bin/bash\necho custom"), 0755); err != nil {
+		t.Fatalf("failed to write custom script: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		command        string
+		baseDir        string
+		projectDir     string
+		wantPath       string
+		wantShell      bool
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name:       "shell command with spaces",
+			command:    "bun scripts/test.ts",
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   "bun scripts/test.ts",
+			wantShell:  true,
+			wantErr:    false,
+		},
+		{
+			name:       "shell command with multiple spaces",
+			command:    "npm run test --watch",
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   "npm run test --watch",
+			wantShell:  true,
+			wantErr:    false,
+		},
+		{
+			name:       "file path resolved from .ramp",
+			command:    "scripts/test.sh",
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   filepath.Join(rampDir, "scripts/test.sh"),
+			wantShell:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "file path resolved from baseDir",
+			command:    "custom.sh",
+			baseDir:    customDir,
+			projectDir: tempDir,
+			wantPath:   customScript,
+			wantShell:  false,
+			wantErr:    false,
+		},
+		{
+			name:       "absolute path",
+			command:    testScript,
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   testScript,
+			wantShell:  false,
+			wantErr:    false,
+		},
+		{
+			name:           "empty command",
+			command:        "",
+			baseDir:        "",
+			projectDir:     tempDir,
+			wantErr:        true,
+			wantErrContain: "command is empty",
+		},
+		{
+			name:           "whitespace-only command",
+			command:        "   ",
+			baseDir:        "",
+			projectDir:     tempDir,
+			wantErr:        true,
+			wantErrContain: "command is empty",
+		},
+		{
+			name:           "tab-only command",
+			command:        "\t\t",
+			baseDir:        "",
+			projectDir:     tempDir,
+			wantErr:        true,
+			wantErrContain: "command is empty",
+		},
+		{
+			name:           "nonexistent file path",
+			command:        "scripts/nonexistent.sh",
+			baseDir:        "",
+			projectDir:     tempDir,
+			wantErr:        true,
+			wantErrContain: "script not found",
+		},
+		{
+			name:       "command with leading/trailing whitespace",
+			command:    "  bun test  ",
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   "bun test",
+			wantShell:  true,
+			wantErr:    false,
+		},
+		{
+			name:       "command with pipe (shell)",
+			command:    "cat file | grep pattern",
+			baseDir:    "",
+			projectDir: tempDir,
+			wantPath:   "cat file | grep pattern",
+			wantShell:  true,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveCommand(tt.command, tt.baseDir, tt.projectDir)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ResolveCommand() expected error, got nil")
+					return
+				}
+				if tt.wantErrContain != "" && !contains(err.Error(), tt.wantErrContain) {
+					t.Errorf("ResolveCommand() error = %q, want error containing %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ResolveCommand() unexpected error: %v", err)
+				return
+			}
+
+			if got.Path != tt.wantPath {
+				t.Errorf("ResolveCommand() Path = %q, want %q", got.Path, tt.wantPath)
+			}
+
+			if got.IsShellCommand != tt.wantShell {
+				t.Errorf("ResolveCommand() IsShellCommand = %v, want %v", got.IsShellCommand, tt.wantShell)
+			}
+		})
+	}
+}
+
+// TestResolveCommandBaseDirPrecedence tests that baseDir takes precedence over projectDir/.ramp/
+func TestResolveCommandBaseDirPrecedence(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create script in both locations with same relative path
+	rampScriptsDir := filepath.Join(tempDir, ".ramp", "scripts")
+	customScriptsDir := filepath.Join(tempDir, "custom", "scripts")
+
+	if err := os.MkdirAll(rampScriptsDir, 0755); err != nil {
+		t.Fatalf("failed to create .ramp/scripts dir: %v", err)
+	}
+	if err := os.MkdirAll(customScriptsDir, 0755); err != nil {
+		t.Fatalf("failed to create custom/scripts dir: %v", err)
+	}
+
+	rampScript := filepath.Join(rampScriptsDir, "run.sh")
+	customScript := filepath.Join(customScriptsDir, "run.sh")
+
+	if err := os.WriteFile(rampScript, []byte("ramp version"), 0755); err != nil {
+		t.Fatalf("failed to write ramp script: %v", err)
+	}
+	if err := os.WriteFile(customScript, []byte("custom version"), 0755); err != nil {
+		t.Fatalf("failed to write custom script: %v", err)
+	}
+
+	// With baseDir set, should resolve from baseDir
+	got, err := ResolveCommand("scripts/run.sh", filepath.Join(tempDir, "custom"), tempDir)
+	if err != nil {
+		t.Fatalf("ResolveCommand() error = %v", err)
+	}
+	if got.Path != customScript {
+		t.Errorf("ResolveCommand() with baseDir should resolve to %q, got %q", customScript, got.Path)
+	}
+
+	// Without baseDir, should resolve from .ramp/
+	got, err = ResolveCommand("scripts/run.sh", "", tempDir)
+	if err != nil {
+		t.Fatalf("ResolveCommand() error = %v", err)
+	}
+	if got.Path != rampScript {
+		t.Errorf("ResolveCommand() without baseDir should resolve to %q, got %q", rampScript, got.Path)
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"ramp/internal/config"
@@ -105,30 +104,25 @@ func matchesCommand(hook *config.Hook, commandName string) bool {
 	return hook.For == commandName // Exact match
 }
 
-// runHook executes a single hook script.
+// runHook executes a single hook script or shell command.
 func runHook(
 	hook *config.Hook,
 	projectDir string,
 	workDir string,
 	env map[string]string,
 ) error {
-	// Resolve script path based on BaseDir (set during config merge)
-	var scriptPath string
-	if filepath.IsAbs(hook.Command) {
-		scriptPath = hook.Command
-	} else if hook.BaseDir != "" {
-		scriptPath = filepath.Join(hook.BaseDir, hook.Command)
-	} else {
-		// Fallback for backward compatibility
-		scriptPath = filepath.Join(projectDir, ".ramp", hook.Command)
-	}
-
-	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
-		return fmt.Errorf("hook script not found: %s", scriptPath)
+	resolved, err := config.ResolveCommand(hook.Command, hook.BaseDir, projectDir)
+	if err != nil {
+		return err
 	}
 
 	// Use login shell (-l) for consistent environment
-	cmd := exec.Command("/bin/bash", "-l", scriptPath)
+	var cmd *exec.Cmd
+	if resolved.IsShellCommand {
+		cmd = exec.Command("/bin/bash", "-l", "-c", resolved.Path)
+	} else {
+		cmd = exec.Command("/bin/bash", "-l", resolved.Path)
+	}
 	cmd.Dir = workDir
 
 	// Build environment

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -117,9 +117,11 @@ func runHook(
 	}
 
 	// Use login shell (-l) for consistent environment
+	// For shell commands, use 'bash -c 'cmd "$@"' _' pattern for safe arg passing
+	// (consistent with operations/run.go even though hooks don't receive args today)
 	var cmd *exec.Cmd
 	if resolved.IsShellCommand {
-		cmd = exec.Command("/bin/bash", "-l", "-c", resolved.Path)
+		cmd = exec.Command("/bin/bash", "-l", "-c", resolved.Path+` "$@"`, "_")
 	} else {
 		cmd = exec.Command("/bin/bash", "-l", resolved.Path)
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -313,3 +313,84 @@ func TestValidateHookEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestRunHook_ShellCommand(t *testing.T) {
+	// Test that hooks can be shell commands (containing spaces)
+	projectDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "marker.txt")
+
+	// Create hook with inline shell command (contains space)
+	hook := &config.Hook{
+		Event:   "up",
+		Command: "echo SHELL_HOOK > " + markerFile,
+	}
+
+	err := runHook(hook, projectDir, projectDir, nil)
+	if err != nil {
+		t.Fatalf("runHook() error = %v", err)
+	}
+
+	// Verify the shell command executed
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("hook did not create marker file: %v", err)
+	}
+
+	if string(content) != "SHELL_HOOK\n" {
+		t.Errorf("marker file content = %q, want %q", string(content), "SHELL_HOOK\n")
+	}
+}
+
+func TestRunHook_ShellCommandWithEnvVars(t *testing.T) {
+	// Test that shell command hooks can access environment variables
+	projectDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "marker.txt")
+
+	hook := &config.Hook{
+		Event:   "up",
+		Command: "echo $TEST_VAR > " + markerFile,
+	}
+
+	env := map[string]string{
+		"TEST_VAR": "ENV_VALUE",
+	}
+
+	err := runHook(hook, projectDir, projectDir, env)
+	if err != nil {
+		t.Fatalf("runHook() error = %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("hook did not create marker file: %v", err)
+	}
+
+	if string(content) != "ENV_VALUE\n" {
+		t.Errorf("marker file content = %q, want %q", string(content), "ENV_VALUE\n")
+	}
+}
+
+func TestRunHook_ShellCommandWithPipe(t *testing.T) {
+	// Test that shell command hooks support pipes
+	projectDir := t.TempDir()
+	markerFile := filepath.Join(t.TempDir(), "marker.txt")
+
+	hook := &config.Hook{
+		Event:   "up",
+		Command: "echo 'line1\nline2\nline3' | grep line2 > " + markerFile,
+	}
+
+	err := runHook(hook, projectDir, projectDir, nil)
+	if err != nil {
+		t.Fatalf("runHook() error = %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("hook did not create marker file: %v", err)
+	}
+
+	if string(content) != "line2\n" {
+		t.Errorf("marker file content = %q, want %q", string(content), "line2\n")
+	}
+}

--- a/internal/operations/run.go
+++ b/internal/operations/run.go
@@ -78,21 +78,13 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		return nil, fmt.Errorf("command '%s' requires a feature name", commandName)
 	}
 
-	// Resolve script path based on BaseDir (set during config merge)
-	var scriptPath string
-	if filepath.IsAbs(command.Command) {
-		scriptPath = command.Command
-	} else if command.BaseDir != "" {
-		scriptPath = filepath.Join(command.BaseDir, command.Command)
-	} else {
-		// Fallback for backward compatibility
-		scriptPath = filepath.Join(projectDir, ".ramp", command.Command)
+	// Resolve the command: detect shell commands vs file paths and resolve paths
+	resolved, resolveErr := config.ResolveCommand(command.Command, command.BaseDir, projectDir)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("command '%s': %w", commandName, resolveErr)
 	}
-
-	// Validate script exists
-	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("command script not found: %s", scriptPath)
-	}
+	scriptPath := resolved.Path
+	isShellCommand := resolved.IsShellCommand
 
 	start := time.Now()
 
@@ -102,7 +94,7 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 	if featureName == "" {
 		// Source mode
 		progress.Start(fmt.Sprintf("Running '%s' against source repositories", commandName))
-		exitCode, err = runInSource(opts, scriptPath)
+		exitCode, err = runInSource(opts, scriptPath, isShellCommand)
 	} else {
 		// Feature mode
 		treesDir := filepath.Join(projectDir, "trees", featureName)
@@ -113,7 +105,7 @@ func RunCommand(opts RunOptions) (*RunResult, error) {
 		}
 
 		progress.Start(fmt.Sprintf("Running '%s' for feature '%s'", commandName, featureName))
-		exitCode, err = runInFeature(opts, scriptPath, treesDir)
+		exitCode, err = runInFeature(opts, scriptPath, treesDir, isShellCommand)
 	}
 
 	duration := time.Since(start)
@@ -185,6 +177,19 @@ func buildBashCommand(scriptPath string, args []string, workDir string) *exec.Cm
 	return cmd
 }
 
+// buildShellCommand creates an exec.Cmd for running a shell command string.
+// Uses bash -l -c to execute arbitrary shell commands (pipes, redirects, etc.).
+// Arguments are passed safely via "$@" to avoid shell injection.
+func buildShellCommand(command string, args []string, workDir string) *exec.Cmd {
+	// Use 'bash -c 'cmd "$@"' _ arg1 arg2' pattern to safely pass arguments
+	// without shell expansion. The "_" is a placeholder for $0.
+	bashArgs := []string{"-l", "-c", command + ` "$@"`, "_"}
+	bashArgs = append(bashArgs, args...)
+	cmd := exec.Command("/bin/bash", bashArgs...)
+	cmd.Dir = workDir
+	return cmd
+}
+
 // appendArgsEnv adds RAMP_ARGS to the environment if args are provided.
 func appendArgsEnv(env []string, args []string) []string {
 	if len(args) > 0 {
@@ -194,7 +199,7 @@ func appendArgsEnv(env []string, args []string) []string {
 }
 
 // runInFeature executes a command in feature mode with feature-specific env vars.
-func runInFeature(opts RunOptions, scriptPath, treesDir string) (int, error) {
+func runInFeature(opts RunOptions, scriptPath, treesDir string, isShellCommand bool) (int, error) {
 	projectDir := opts.ProjectDir
 	cfg := opts.Config
 	featureName := opts.FeatureName
@@ -209,7 +214,12 @@ func runInFeature(opts RunOptions, scriptPath, treesDir string) (int, error) {
 		}
 	}
 
-	cmd := buildBashCommand(scriptPath, opts.Args, treesDir)
+	var cmd *exec.Cmd
+	if isShellCommand {
+		cmd = buildShellCommand(scriptPath, opts.Args, treesDir)
+	} else {
+		cmd = buildBashCommand(scriptPath, opts.Args, treesDir)
+	}
 
 	// Build environment variables using the standard builder, but override repo paths for worktrees
 	repos := cfg.GetRepos()
@@ -231,11 +241,16 @@ func runInFeature(opts RunOptions, scriptPath, treesDir string) (int, error) {
 }
 
 // runInSource executes a command in source mode against the project directory.
-func runInSource(opts RunOptions, scriptPath string) (int, error) {
+func runInSource(opts RunOptions, scriptPath string, isShellCommand bool) (int, error) {
 	projectDir := opts.ProjectDir
 	cfg := opts.Config
 
-	cmd := buildBashCommand(scriptPath, opts.Args, projectDir)
+	var cmd *exec.Cmd
+	if isShellCommand {
+		cmd = buildShellCommand(scriptPath, opts.Args, projectDir)
+	} else {
+		cmd = buildBashCommand(scriptPath, opts.Args, projectDir)
+	}
 
 	// Build environment variables (excluding feature-specific vars)
 	cmd.Env = append(os.Environ(),

--- a/internal/operations/run_test.go
+++ b/internal/operations/run_test.go
@@ -821,3 +821,355 @@ echo "ARG2=$2"
 		t.Errorf("Expected ARG2=--flag=value, got output: %v", output.Lines)
 	}
 }
+
+// === SHELL COMMAND TESTS ===
+
+// AddShellCommand adds a custom command with an inline shell command (not a script file)
+func (tp *TestProject) AddShellCommand(name, command, scope string) {
+	tp.t.Helper()
+
+	tp.Config.Commands = append(tp.Config.Commands, &config.Command{
+		Name:    name,
+		Command: command,
+		Scope:   scope,
+	})
+
+	if err := config.SaveConfig(tp.Config, tp.Dir); err != nil {
+		tp.t.Fatalf("failed to save config: %v", err)
+	}
+}
+
+func TestRunCommand_ShellCommand_SourceMode(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Add a shell command (not a script file)
+	tp.AddShellCommand("echo-test", "echo 'SHELL_COMMAND_WORKS'", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	// Run the shell command in source mode
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "echo-test",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify the shell command executed
+	found := false
+	for _, line := range output.Lines {
+		if line == "SHELL_COMMAND_WORKS" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'SHELL_COMMAND_WORKS' in output, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_FeatureMode(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Add a shell command with feature scope
+	tp.AddShellCommand("echo-feature", "echo \"FEATURE=$RAMP_WORKTREE_NAME\"", "feature")
+
+	progress := &MockProgressReporter{}
+
+	// Create a feature first
+	_, err := Up(UpOptions{
+		FeatureName: "my-feature",
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		Progress:    progress,
+		SkipRefresh: true,
+	})
+	if err != nil {
+		t.Fatalf("Up() error = %v", err)
+	}
+
+	output := &MockOutputStreamer{}
+
+	// Run the shell command in feature mode
+	_, err = RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "echo-feature",
+		FeatureName: "my-feature",
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify the shell command executed with feature env var
+	found := false
+	for _, line := range output.Lines {
+		if line == "FEATURE=my-feature" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'FEATURE=my-feature' in output, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_WithPipe(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Add a shell command that uses pipe
+	tp.AddShellCommand("pipe-test", "echo 'line1\nline2\nline3' | grep line2", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "pipe-test",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify pipe worked
+	found := false
+	for _, line := range output.Lines {
+		if line == "line2" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'line2' in output from pipe command, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_WithArgs(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Add a shell command that uses arguments
+	// Note: command must contain a space to be recognized as a shell command
+	tp.AddShellCommand("echo-with-args", "echo PREFIX:", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	// Run with arguments (these get appended to the command)
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "echo-with-args",
+		FeatureName: "", // source mode
+		Args:        []string{"hello", "world"},
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify args were passed to shell command
+	found := false
+	for _, line := range output.Lines {
+		if line == "PREFIX: hello world" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'PREFIX: hello world' in output, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_ArgsWithSpecialChars(t *testing.T) {
+	// Test that arguments with shell metacharacters are handled safely
+	// (no shell injection via $(), backticks, semicolons, etc.)
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Shell command that echoes its arguments (needs space to be recognized as shell command)
+	// Using "echo --" so the space is preserved after TrimSpace
+	tp.AddShellCommand("echo-special", "echo --", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	// Arguments with characters that would be dangerous if shell-expanded
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "echo-special",
+		FeatureName: "", // source mode
+		Args:        []string{"$HOME", "$(whoami)", "`id`", "a;b", "a&&b"},
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Arguments should be passed literally, not shell-expanded
+	// If shell injection occurred, $HOME would expand to a path, $(whoami) to a username, etc.
+	// Note: "echo --" outputs "-- " followed by args
+	found := false
+	for _, line := range output.Lines {
+		if line == "-- $HOME $(whoami) `id` a;b a&&b" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected literal args without shell expansion, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_BunScript(t *testing.T) {
+	// This test simulates the issue: running a bun/node script directly
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Create a simple test script in the project root (where shell commands run)
+	scriptsDir := filepath.Join(tp.Dir, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0755); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+
+	// Create a simple script that outputs something
+	scriptContent := `#!/usr/bin/env bash
+echo "EXECUTED_VIA_SHELL"
+`
+	scriptPath := filepath.Join(scriptsDir, "test-script.sh")
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	// Add command that runs it via shell (like "bun scripts/test.ts" would)
+	// Using bash instead of bun for test portability
+	// Shell commands run from the project directory, so use relative path from there
+	tp.AddShellCommand("run-script", "bash scripts/test-script.sh", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "run-script",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify script was executed via shell
+	found := false
+	for _, line := range output.Lines {
+		if line == "EXECUTED_VIA_SHELL" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'EXECUTED_VIA_SHELL' in output, got: %v", output.Lines)
+	}
+}
+
+func TestRunCommand_ShellCommand_EnvVarSubstitution(t *testing.T) {
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Add a shell command that uses environment variable
+	tp.AddShellCommand("env-test", "echo \"PROJECT=$RAMP_PROJECT_DIR\"", "")
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "env-test",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify env var was substituted
+	expected := "PROJECT=" + tp.Dir
+	found := false
+	for _, line := range output.Lines {
+		if line == expected {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected '%s' in output, got: %v", expected, output.Lines)
+	}
+}
+
+func TestRunCommand_ScriptFile_StillWorks(t *testing.T) {
+	// Verify that existing script file commands still work
+	tp := NewTestProject(t)
+	tp.InitRepo("repo1")
+
+	// Use the existing AddCommand helper which creates a script file
+	tp.AddCommand("script-test", `#!/bin/bash
+echo "SCRIPT_FILE_WORKS"
+`)
+
+	progress := &MockProgressReporter{}
+	output := &MockOutputStreamer{}
+
+	_, err := RunCommand(RunOptions{
+		ProjectDir:  tp.Dir,
+		Config:      tp.Config,
+		CommandName: "script-test",
+		FeatureName: "", // source mode
+		Progress:    progress,
+		Output:      output,
+	})
+	if err != nil {
+		t.Fatalf("RunCommand() error = %v", err)
+	}
+
+	// Verify script executed
+	found := false
+	for _, line := range output.Lines {
+		if line == "SCRIPT_FILE_WORKS" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("Expected 'SCRIPT_FILE_WORKS' in output, got: %v", output.Lines)
+	}
+}


### PR DESCRIPTION
## Key Changes
- Add shell command detection: commands with spaces run via `bash -l -c`, without spaces as file paths
- Extract shared `ResolveCommand()` function in config package to eliminate duplication
- Use safe argument passing pattern (`bash -c 'cmd "$@"' _`) to prevent shell injection
- Support shell commands in both custom commands and hooks

## Files Changed
- `internal/config/config.go` - New `ResolveCommand()` function with space-based heuristic
- `internal/operations/run.go` - `buildShellCommand()` helper with safe arg handling
- `internal/hooks/hooks.go` - Shell command support using shared resolver
- `internal/operations/run_test.go` - Tests for shell commands including security test
- `internal/hooks/hooks_test.go` - Tests for shell command hooks
- `cmd/run_test.go` - Updated error message assertion

## Risks & Considerations
- Commands with spaces in their file path (e.g., `my scripts/run.sh`) will be misclassified as shell commands
- Documented heuristic: no spaces = file path, spaces = shell command

Closes #102